### PR TITLE
処理時間の計測処理を追加

### DIFF
--- a/browser/app/next.config.js
+++ b/browser/app/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   reactStrictMode: true,
+  publicRuntimeConfig: {
+    detectorBaseUrl: process.env.DETECTOR_BASE_URL,
+  },
 }

--- a/browser/app/pages/api/compare.js
+++ b/browser/app/pages/api/compare.js
@@ -1,4 +1,7 @@
 import http from "http";
+import getConfig from "next/config";
+
+const { publicRuntimeConfig } = getConfig();
 
 export const config = {
   api: {
@@ -6,12 +9,10 @@ export const config = {
   },
 };
 
-const BACKEND_BASE_URL = "http://detector-insightface:8000";
-
 // REF: https://github.com/rchipka/node-osmosis/blob/1d432e6c6b190a1a7bf415c62bb8ab0d7ce04e56/test/proxy.js#L8
 export default async function handler(frontend_req, frontend_res) {
   return new Promise((resolve, reject) => {
-    const backend_req = http.request(BACKEND_BASE_URL + "/compare", {
+    const backend_req = http.request(publicRuntimeConfig.detectorBaseUrl + "/compare", {
       method: frontend_req.method,
       headers: frontend_req.headers,
     });

--- a/browser/app/pages/api/detect.js
+++ b/browser/app/pages/api/detect.js
@@ -1,4 +1,7 @@
 import http from "http";
+import getConfig from "next/config";
+
+const { publicRuntimeConfig } = getConfig();
 
 export const config = {
   api: {
@@ -6,12 +9,10 @@ export const config = {
   },
 };
 
-const BACKEND_BASE_URL = "http://detector-insightface:8000";
-
 // REF: https://github.com/rchipka/node-osmosis/blob/1d432e6c6b190a1a7bf415c62bb8ab0d7ce04e56/test/proxy.js#L8
 export default async function handler(frontend_req, frontend_res) {
   return new Promise((resolve, reject) => {
-    const backend_req = http.request(BACKEND_BASE_URL + "/detect", {
+    const backend_req = http.request(publicRuntimeConfig.detectorBaseUrl + "/detect", {
       method: frontend_req.method,
       headers: frontend_req.headers,
     });

--- a/browser/app/pages/compare.js
+++ b/browser/app/pages/compare.js
@@ -58,7 +58,7 @@ async function makeMatrix(embeddings1, embeddings2) {
   }
 
   const response = await compare({embeddings, pairs});
-  response.pairs.forEach((pair) => {
+  response.response.pairs.forEach((pair) => {
     matrix[pair.index1][pair.index2 - embeddings1.length] = pair.similarity;
   });
 

--- a/browser/app/pages/detect.js
+++ b/browser/app/pages/detect.js
@@ -145,12 +145,12 @@ function Face({ face, color, shows }) {
       }
       {!shows.landmarks2d106 ? null :
         <KeyPoints
-            points={face.landmarks["2d_106"]}
+            points={face.landmarks2d106}
             color={"#CC0000"} />
       }
       {!shows.landmarks3d68 ? null :
         <KeyPoints
-            points={face.landmarks["3d_68"]}
+            points={face.landmarks3d68}
             color={"#0000CC"} />
       }
       {!shows.keyPoints ? null :

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -84,26 +84,24 @@ class DetectResponse(BaseModel):
     response: Response
 
 
-class PairRequest(BaseModel):
-    index1: int
-    index2: int
-
-
 class CompareRequest(BaseModel):
+    class Pair(BaseModel):
+        index1: int
+        index2: int
+
     embeddings: List[str]
-    pairs: List[PairRequest]
-
-
-class PairResponse(BaseModel):
-    index1: int
-    index2: int
-    similarity: float
+    pairs: List[Pair]
 
 
 class CompareResponse(BaseModel):
+    class Pair(BaseModel):
+        index1: int
+        index2: int
+        similarity: float
+
     comparisonTimeInNanoseconds: int
     embeddings: List[str]
-    pairs: List[PairResponse]
+    pairs: List[Pair]
 
 
 def encode_np(array):

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -37,7 +37,7 @@ def round(value, factor):
 
 SERVICE = {
     "name": "detector-insightface",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "computingDevice": onnxruntime.get_device(),
     "libraries": {
         "insightface": insightface.__version__,

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -104,20 +104,18 @@ async def post_detect(file: fastapi.UploadFile = fastapi.File(...)):
                         {"x": round(xy[0], 100), "y": round(xy[1], 100)}
                         for xy in face.kps
                     ],
-                    "landmarks": {
-                        "3d_68": [
-                            {
-                                "x": round(xyz[0], 100),
-                                "y": round(xyz[1], 100),
-                                "z": round(xyz[2], 100),
-                            }
-                            for xyz in face.landmark_3d_68
-                        ],
-                        "2d_106": [
-                            {"x": round(xy[0], 100), "y": round(xy[1], 100),}
-                            for xy in face.landmark_2d_106
-                        ],
-                    },
+                    "landmarks3d68": [
+                        {
+                            "x": round(xyz[0], 100),
+                            "y": round(xyz[1], 100),
+                            "z": round(xyz[2], 100),
+                        }
+                        for xyz in face.landmark_3d_68
+                    ],
+                    "landmarks2d106": [
+                        {"x": round(xy[0], 100), "y": round(xy[1], 100),}
+                        for xy in face.landmark_2d_106
+                    ],
                     "attributes": {"sex": face.sex, "age": face.age},
                     "embedding": encode_np(face.embedding),
                 }

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -94,14 +94,27 @@ class CompareRequest(BaseModel):
 
 
 class CompareResponse(BaseModel):
-    class Pair(BaseModel):
-        index1: int
-        index2: int
-        similarity: float
+    class Request(BaseModel):
+        class Pair(BaseModel):
+            index1: int
+            index2: int
 
-    comparisonTimeInNanoseconds: int
-    embeddings: List[str]
-    pairs: List[Pair]
+        embeddings: List[str]
+        pairs: List[Pair]
+
+    class Response(BaseModel):
+        class Pair(BaseModel):
+            index1: int
+            index2: int
+            similarity: float
+
+        comparisonTimeInNanoseconds: int
+        pairs: List[Pair]
+
+    service: ServiceResponse
+    time: int
+    request: Request
+    response: Response
 
 
 def encode_np(array):
@@ -228,10 +241,18 @@ async def post_compare(request: CompareRequest):
     process_time_ns = time.perf_counter_ns() - start_time_ns
 
     return {
-        "comparisonTimeInNanoseconds": process_time_ns,
-        "embeddings": embeddings,
-        "pairs": [
-            {"index1": pair.index1, "index2": pair.index2, "similarity": similarity,}
-            for pair, similarity in zip(request.pairs, similarities)
-        ],
+        "service": SERVICE,
+        "time": int(datetime.datetime.now().timestamp() * 1000),
+        "request": {"embeddings": embeddings, "pairs": request.pairs,},
+        "response": {
+            "comparisonTimeInNanoseconds": process_time_ns,
+            "pairs": [
+                {
+                    "index1": pair.index1,
+                    "index2": pair.index2,
+                    "similarity": similarity,
+                }
+                for pair, similarity in zip(request.pairs, similarities)
+            ],
+        },
     }

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -5,13 +5,25 @@ import io
 import time
 
 from pydantic import BaseModel
-from typing import List
+from typing import List, Dict
 import fastapi
 import fastapi.middleware.cors
 import insightface
 import numpy as np
 import onnxruntime
 import PIL.Image
+
+
+class ServiceResponse(BaseModel):
+    name: str
+    version: str
+    computingDevice: str
+    libraries: Dict[str, str]
+
+
+class RootResponse(BaseModel):
+    service: ServiceResponse
+    time: int
 
 
 class PairRequest(BaseModel):
@@ -75,7 +87,7 @@ face_analysis = insightface.app.FaceAnalysis()
 face_analysis.prepare(ctx_id=0, det_size=(640, 640))
 
 
-@app.get("/")
+@app.get("/", response_model=RootResponse)
 async def get_root():
     return {
         "service": SERVICE,

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -5,7 +5,7 @@ import io
 import time
 
 from pydantic import BaseModel
-from typing import List, Dict
+from typing import List, Dict, Any
 import fastapi
 import fastapi.middleware.cors
 import insightface
@@ -24,6 +24,36 @@ class ServiceResponse(BaseModel):
 class RootResponse(BaseModel):
     service: ServiceResponse
     time: int
+
+
+class DetectResponse(BaseModel):
+    class RequestResponse(BaseModel):
+        class FileResponse(BaseModel):
+            name: str
+            size: int
+            sha1: str
+
+        file: FileResponse
+
+    class ResponseResponse(BaseModel):
+        class FaceResponse(BaseModel):
+            score: float
+            boundingBox: Dict[str, float]
+            keyPoints: List[Dict[str, float]]
+            landmarks: Dict[str, List[Dict[str, float]]]
+            attributes: Dict[str, Any]
+            embedding: str
+
+        detectionTimeInNanoseconds: int
+        width: int
+        height: int
+        numberOfFaces: int
+        faces: List[FaceResponse]
+
+    service: ServiceResponse
+    time: int
+    request: RequestResponse
+    response: ResponseResponse
 
 
 class PairRequest(BaseModel):
@@ -95,7 +125,7 @@ async def get_root():
     }
 
 
-@app.post("/detect")
+@app.post("/detect", response_model=DetectResponse)
 async def post_detect(file: fastapi.UploadFile = fastapi.File(...)):
     assert file.content_type == "image/jpeg"
     image = PIL.Image.open(file.file).convert("RGB")

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -27,19 +27,29 @@ class RootResponse(BaseModel):
 
 
 class DetectResponse(BaseModel):
-    class RequestResponse(BaseModel):
-        class FileResponse(BaseModel):
+    class Request(BaseModel):
+        class File(BaseModel):
             name: str
             size: int
             sha1: str
 
-        file: FileResponse
+        file: File
 
-    class ResponseResponse(BaseModel):
-        class FaceResponse(BaseModel):
+    class Response(BaseModel):
+        class Face(BaseModel):
+            class BoundingBox(BaseModel):
+                x1: float
+                y1: float
+                x2: float
+                y2: float
+
+            class Point2D(BaseModel):
+                x: float
+                y: float
+
             score: float
-            boundingBox: Dict[str, float]
-            keyPoints: List[Dict[str, float]]
+            boundingBox: BoundingBox
+            keyPoints: List[Point2D]
             landmarks: Dict[str, List[Dict[str, float]]]
             attributes: Dict[str, Any]
             embedding: str
@@ -48,12 +58,12 @@ class DetectResponse(BaseModel):
         width: int
         height: int
         numberOfFaces: int
-        faces: List[FaceResponse]
+        faces: List[Face]
 
     service: ServiceResponse
     time: int
-    request: RequestResponse
-    response: ResponseResponse
+    request: Request
+    response: Response
 
 
 class PairRequest(BaseModel):

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -26,6 +26,17 @@ class RootResponse(BaseModel):
     time: int
 
 
+class Point2D(BaseModel):
+    x: float
+    y: float
+
+
+class Point3D(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
 class DetectResponse(BaseModel):
     class Request(BaseModel):
         class File(BaseModel):
@@ -43,15 +54,22 @@ class DetectResponse(BaseModel):
                 x2: float
                 y2: float
 
-            class Point2D(BaseModel):
-                x: float
-                y: float
+            class Landmarks(BaseModel):
+                class Config:
+                    fields = {"a3d_68": "3d_68", "a2d_106": "2d_106"}
+
+                a3d_68: List[Point3D]
+                a2d_106: List[Point2D]
+
+            class Attributes(BaseModel):
+                sex: str
+                age: int
 
             score: float
             boundingBox: BoundingBox
             keyPoints: List[Point2D]
-            landmarks: Dict[str, List[Dict[str, float]]]
-            attributes: Dict[str, Any]
+            landmarks: Landmarks
+            attributes: Attributes
             embedding: str
 
         detectionTimeInNanoseconds: int

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -67,6 +67,9 @@ async def get_root():
 
 @app.post("/detect", response_model=mytypes.DetectResponse)
 async def post_detect(file: fastapi.UploadFile = fastapi.File(...)):
+    # TODO: PNG形式に対応する。
+    # TODO: NumPy形式に対応する。
+    # TODO: OpenCVを使って画像を読み込むように変更する。（回転情報に対応するため）
     assert file.content_type == "image/jpeg"
     image = PIL.Image.open(file.file).convert("RGB")
     image = np.array(image)

--- a/detector-insightface/src/main.py
+++ b/detector-insightface/src/main.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import hashlib
 import io
+import time
 
 from pydantic import BaseModel
 from typing import List
@@ -88,7 +89,9 @@ async def post_detect(file: fastapi.UploadFile = fastapi.File(...)):
     image = np.array(image)
     image = image[:, :, [2, 1, 0]]  # RGB to BGR
 
+    start_time_ns = time.perf_counter_ns()
     faces = face_analysis.get(image)
+    detection_time_ns = time.perf_counter_ns() - start_time_ns
 
     file.file.seek(0)
     sha1_hash = hashlib.sha1(file.file.read()).hexdigest()
@@ -101,6 +104,7 @@ async def post_detect(file: fastapi.UploadFile = fastapi.File(...)):
             "file": {"name": file.filename, "size": file_size, "sha1": sha1_hash}
         },
         "response": {
+            "detectionTimeInNanoseconds": detection_time_ns,
             "width": image.shape[1],
             "height": image.shape[0],
             "numberOfFaces": len(faces),

--- a/detector-insightface/src/mytypes.py
+++ b/detector-insightface/src/mytypes.py
@@ -1,0 +1,105 @@
+from pydantic import BaseModel
+from typing import List, Dict
+
+
+class ServiceResponse(BaseModel):
+    name: str
+    version: str
+    computingDevice: str
+    libraries: Dict[str, str]
+
+
+class RootResponse(BaseModel):
+    service: ServiceResponse
+    time: int
+
+
+class Point2D(BaseModel):
+    x: float
+    y: float
+
+
+class Point3D(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
+class DetectResponse(BaseModel):
+    class Request(BaseModel):
+        class File(BaseModel):
+            name: str
+            size: int
+            sha1: str
+
+        file: File
+
+    class Response(BaseModel):
+        class Face(BaseModel):
+            class BoundingBox(BaseModel):
+                x1: float
+                y1: float
+                x2: float
+                y2: float
+
+            class Landmarks(BaseModel):
+                class Config:
+                    fields = {"a3d_68": "3d_68", "a2d_106": "2d_106"}
+
+                a3d_68: List[Point3D]
+                a2d_106: List[Point2D]
+
+            class Attributes(BaseModel):
+                sex: str
+                age: int
+
+            score: float
+            boundingBox: BoundingBox
+            keyPoints: List[Point2D]
+            landmarks: Landmarks
+            attributes: Attributes
+            embedding: str
+
+        detectionTimeInNanoseconds: int
+        width: int
+        height: int
+        numberOfFaces: int
+        faces: List[Face]
+
+    service: ServiceResponse
+    time: int
+    request: Request
+    response: Response
+
+
+class CompareRequest(BaseModel):
+    class Pair(BaseModel):
+        index1: int
+        index2: int
+
+    embeddings: List[str]
+    pairs: List[Pair]
+
+
+class CompareResponse(BaseModel):
+    class Request(BaseModel):
+        class Pair(BaseModel):
+            index1: int
+            index2: int
+
+        embeddings: List[str]
+        pairs: List[Pair]
+
+    class Response(BaseModel):
+        class Pair(BaseModel):
+            index1: int
+            index2: int
+            similarity: float
+
+        comparisonTimeInNanoseconds: int
+        pairs: List[Pair]
+
+    service: ServiceResponse
+    time: int
+    request: Request
+    response: Response

--- a/detector-insightface/src/mytypes.py
+++ b/detector-insightface/src/mytypes.py
@@ -42,13 +42,6 @@ class DetectResponse(BaseModel):
                 x2: float
                 y2: float
 
-            class Landmarks(BaseModel):
-                class Config:
-                    fields = {"a3d_68": "3d_68", "a2d_106": "2d_106"}
-
-                a3d_68: List[Point3D]
-                a2d_106: List[Point2D]
-
             class Attributes(BaseModel):
                 sex: str
                 age: int
@@ -56,7 +49,8 @@ class DetectResponse(BaseModel):
             score: float
             boundingBox: BoundingBox
             keyPoints: List[Point2D]
-            landmarks: Landmarks
+            landmarks3d68: List[Point3D]
+            landmarks2d106: List[Point2D]
             attributes: Attributes
             embedding: str
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     build: "browser"
     ports:
       - "8001:3000"
+    environment:
+      DETECTOR_BASE_URL: http://detector-insightface:8000
     # volumes:
       # - "./browser:/mnt/workspace" # DEBUG:
     # working_dir: "/mnt/workspace/app" # DEBUG:


### PR DESCRIPTION
# 概要

処理時間の計測処理を追加しました。その他、以下の変更も行いました。

* `browser`サービスが利用するバックエンドのURLを環境変数化しました。
* 顔検出API、顔特徴量比較APIのレスポンスのデータ形式を変更しました。
* レスポンスの浮動小数点数の精度を必要最低限に変更しました。
